### PR TITLE
Attempt to fix issue where sometimes images are too small

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -245,10 +245,10 @@ class FDownloader:
                     try:
                         # Resizing window size for exactly manga page size
                         width = self.browser.execute_script(
-                            f"return document.getElementsByTagName('canvas')[{n-2}].width"
+                            f"return document.getElementsByClassName('layer')[{n-2}].firstChild.width"
                         )
                         height = self.browser.execute_script(
-                            f"return document.getElementsByTagName('canvas')[{n-2}].height"
+                            f"return document.getElementsByClassName('layer')[{n-2}].firstChild.height"
                         )
                         self.browser.set_window_size(width, height)
                     except JavascriptException:


### PR DESCRIPTION
Occasionally a manga ends up reading as 300x150 for the cover and 300x424 for all subsequent pages.  This results in a slice of the cover and all the images are too small even when the full page is there.  This changes where it looks for the page information to a node coming off the layer class rather than the canvas tag.  Same math applies.  For the ones that worked this still works with those afaik.  I've retrieved around 1000 mangas from the site so far and they all seemed to have grabbed properly and without issue.  Ref: https://github.com/Witness-senpai/fakku-downloader/issues/44 https://github.com/Witness-senpai/fakku-downloader/issues/13 https://github.com/Witness-senpai/fakku-downloader/issues/12